### PR TITLE
Suggested fix for World

### DIFF
--- a/src/main/scala/org/tpolecat/tiny/world/World.scala
+++ b/src/main/scala/org/tpolecat/tiny/world/World.scala
@@ -14,7 +14,7 @@ trait World extends EffectWorld {
     def map[B](f: A => B): Action[B] =
       new Action(w => for { p <- t(w) } yield (p._1, f(p._2)))
     def flatMap[B](f: A => Action[B]): Action[B] =
-      new Action(w => for { p <- t(w); x <- f(p._2).t(w) } yield x)
+      new Action(w => for { p <- t(w); x <- f(p._2).t(p._1) } yield x)
   }
 
   object Action {


### PR DESCRIPTION
I could be wrong, but I think that in Action.flatMap, the flatMapped
action should be used with the updated world state p._1, not the old
state 1. This means that when using immutable states, we can see
changes to the state in the flatMapped action.
